### PR TITLE
[FEAT]: 채식 성향 변경 기능 병합

### DIFF
--- a/src/main/java/com/beginvegan/domain/user/application/UserService.java
+++ b/src/main/java/com/beginvegan/domain/user/application/UserService.java
@@ -54,32 +54,15 @@ public class UserService {
         return ResponseEntity.ok(userDetailRes);
     }
 
-    // Description : 비건테스트 결과 조회
+    // Description : 비건 타입 변경
     @Transactional
-    public ResponseEntity<?> getVeganTestResult(UserPrincipal userPrincipal, VeganType veganType) {
+    public ResponseEntity<?> updateVeganType(UserPrincipal userPrincipal, UpdateVeganTypeReq updateVeganTypeReq, String type) {
         User user = validateUserById(userPrincipal.getId());
-
-        user.updateVeganType(veganType);
-        // 최초 1회인지 확인하여 포인트 부여
-        rewardInitialVeganTest(user);
-
-        VeganTestResultRes veganTestResultRes = VeganTestResultRes.builder()
-                .nickname(user.getNickname())
-                .veganType(user.getVeganType())
-                .build();
-
-        ApiResponse apiResponse = ApiResponse.builder()
-                .check(true)
-                .information(veganTestResultRes).build();
-        return  ResponseEntity.ok(apiResponse);
-    }
-
-    // Description : [마이페이지] 비건 타입 변경
-    @Transactional
-    public ResponseEntity<?> updateVeganType(UserPrincipal userPrincipal, UpdateVeganTypeReq updateVeganTypeReq) {
-        User user = validateUserById(userPrincipal.getId());
-
         user.updateVeganType(updateVeganTypeReq.getVeganType());
+        if (Objects.equals(type, "TEST")) {
+            // 최초 1회인지 확인하여 포인트 부여
+            rewardInitialVeganTest(user);
+        }
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)

--- a/src/main/java/com/beginvegan/domain/user/presentation/UserController.java
+++ b/src/main/java/com/beginvegan/domain/user/presentation/UserController.java
@@ -72,25 +72,13 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "유저 비건 타입 변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
             @ApiResponse(responseCode = "400", description = "유저 비건 타입 변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
     })
-    @PatchMapping("/vegan-type")
+    @PatchMapping("/vegan-type/{type}")
     public ResponseEntity<?> updateVeganType(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "UpdateVeganTypeReq Schema를 확인해주세요", required = true) @RequestBody UpdateVeganTypeReq updateVeganTypeReq
+            @Parameter(description = "UpdateVeganTypeReq Schema를 확인해주세요", required = true) @RequestBody UpdateVeganTypeReq updateVeganTypeReq,
+            @Parameter(description = "어느 페이지의 채식 성향 변경인지에 따라 type으로 입력합니다. TEST(채식 성향 테스트일 경우), MYPAGE(마이페이지일 경우)", required = true) @PathVariable String type
             ) {
-        return userService.updateVeganType(userPrincipal, updateVeganTypeReq);
-    }
-
-    @Operation(summary = "비건 테스트 결과 조회", description = "비건 테스트 결과를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "비건 테스트 결과 조회 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = VeganTestResultRes.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "비건 테스트 결과 조회 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @GetMapping("/vegan-test/{veganType}")
-    public ResponseEntity<?> getVeganTestResult(
-            @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "veganType을 입력해주세요.", required = true) @PathVariable VeganType veganType
-    ) {
-        return userService.getVeganTestResult(userPrincipal, veganType);
+        return userService.updateVeganType(userPrincipal, updateVeganTypeReq, type);
     }
 
     @Operation(summary = "유저 프로필 변경", description = "유저의 프로필을 변경합니다.")


### PR DESCRIPTION
## 🌻 Summary
> 내용을 적어주세요.
- 채식 성향 변경 기능 병합

## 👩🏻‍💻 Working
> 작업 내용을 적어주세요.
- 기존 채식 테스트 성향 조회와 (마이페이지)채식 성향 변경 API를 통합

## 📢 Comment
> 코멘트를 작성해주세요.
- type으로 채식 성향 테스트인지, 마이페이지의 채식 성향 변경인지 구분하여 사용


closes #53 